### PR TITLE
Use re.DOTALL to handle newlines in strings.

### DIFF
--- a/src/format_cef/_cef/base.py
+++ b/src/format_cef/_cef/base.py
@@ -75,7 +75,7 @@ def float_sanitiser():
 
 
 def str_sanitiser(regex_str=".*", escape_chars="", min_len=0, max_len=None):
-    regex = re.compile("^{}$".format(regex_str))
+    regex = re.compile("^{}$".format(regex_str), flags=re.DOTALL)
     escape = escaper(escape_chars)
 
     def sanitise(s, debug_name):


### PR DESCRIPTION
I had `format_cef._cef.base.CefValueError: message: 'something\nover\nmany\nlines\n' did not match regex '.*'`
 and now it looks like 
```
CEF:0|Osirium Ltd|Osirium PAM|9.0.0~rc4+g58c6469c|error|An error has occured|10|msg=something
over
many
lines
```